### PR TITLE
Fix Markdown errors + update sys. requirements

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,31 +1,31 @@
-#SoundflowerBed 2.0.0
+# SoundflowerBed 2.0.0
 
 SoundflowerBed is an application that resides in the menu bar allowing you to tap into Soundflower channels and route them to an audio device.
 
-##Download
+## Download
 
 Clone this project and compile SoundflowerBed using Xcode 6 or head over to the [releases page](https://github.com/mLupine/SoundflowerBed/releases) and download a compiled binary.
 
-##Changelog
+## Changelog
 
-###2.0.0
+### 2.0.0
 
-* Updated to work on OS X 10.9 and 10.10
+* Updated to work on OS X 10.9, 10.10, 10.11, 10.12, 10.13, and 10.14
 * Name changed to SoundflowerBed (from Soundflowerbed)
 * New icons
 * New bundle name
 * Small bug fixes
 
-##Copyrights
+## Copyrights
 
-* Originally by ma++ ingalls for Cycling'74 matt@sfsound.org
+* Originally by Matt Ingalls for Cycling'74 (<matt@sfsound.org>)
 
-* Revised by Tim Place, 16 October 2008, for version 1.4 tim@electrotap.com
+* Revised by Tim Place, 16 October 2008, for version 1.4 (<tim@electrotap.com>)
 
-* **Fixed for OS X Mavericks and Yosemite on 20 December 2014, by Maciej Wilczyński <maciej@lupine.cc>**
+* Fixed for OS X Mavericks and later on 20 December 2014, by Maciej Wilczyński (<maciej@lupine.cc>)
 
 
-##LICENSE
+## License
 
 SoundflowerBed is licensed under the terms of the **MIT license**.  
 For details please refer to the accompanying 'License.txt' file distributed with SoundflowerBed.


### PR DESCRIPTION
Fixed Markdown errors and updated readme to show that SoundflowerBed also works on 10.11, 10.12, 10.13, and 10.14.